### PR TITLE
Rename ibeis import references to wbia

### DIFF
--- a/_graveyard/train_pyrf_elephant.py
+++ b/_graveyard/train_pyrf_elephant.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function
 from os.path import join, split, isdir
 from pyrf import Random_Forest_Detector
-from ibeis.detecttools.directory import Directory
-from ibeis.detecttools.ibeisdata import IBEIS_Data
+from wbia.detecttools.directory import Directory
+from wbia.detecttools.wbiadata import IBEIS_Data
 import utool
 import sys
 import shutil

--- a/_graveyard/train_pyrf_giraffe.py
+++ b/_graveyard/train_pyrf_giraffe.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function
 from os.path import join, split, isdir
 from pyrf import Random_Forest_Detector
-from ibeis.detecttools.directory import Directory
-from ibeis.detecttools.ibeisdata import IBEIS_Data
+from wbia.detecttools.directory import Directory
+from wbia.detecttools.wbiadata import IBEIS_Data
 import utool
 import sys
 import shutil

--- a/_graveyard/train_pyrf_zebra_grevys.py
+++ b/_graveyard/train_pyrf_zebra_grevys.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function
 from os.path import join, split, isdir
 from pyrf import Random_Forest_Detector
-from ibeis.detecttools.directory import Directory
-from ibeis.detecttools.ibeisdata import IBEIS_Data
+from wbia.detecttools.directory import Directory
+from wbia.detecttools.wbiadata import IBEIS_Data
 import utool
 import sys
 import shutil

--- a/_graveyard/train_pyrf_zebra_plains.py
+++ b/_graveyard/train_pyrf_zebra_plains.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function
 from os.path import join, split, isdir
 from pyrf import Random_Forest_Detector
-from ibeis.detecttools.directory import Directory
-from ibeis.detecttools.ibeisdata import IBEIS_Data
+from wbia.detecttools.directory import Directory
+from wbia.detecttools.wbiadata import IBEIS_Data
 import utool
 import sys
 import shutil

--- a/_test/test.py
+++ b/_test/test.py
@@ -4,7 +4,7 @@ from os.path import join, exists  # NOQA
 import cv2
 import random
 from pyrf import Random_Forest_Detector
-from ibeis.detecttools.directory import Directory
+from wbia.detecttools.directory import Directory
 
 
 def _draw_box(img, annotation, xmin, ymin, xmax, ymax, color, stroke=2, top=True):

--- a/pyrf/_pyrf.py
+++ b/pyrf/_pyrf.py
@@ -9,7 +9,7 @@ import time
 import shutil
 from collections import OrderedDict as odict
 from os.path import join, exists, abspath, isdir
-from ibeis.detecttools.directory import Directory
+from wbia.detecttools.directory import Directory
 from pyrf.pyrf_helpers import (_load_c_shared_library, _cast_list_to_c, ensure_bytes_strings, _cache_data, _extract_np_array)
 
 

--- a/pyrf/pyrf_helpers.py
+++ b/pyrf/pyrf_helpers.py
@@ -8,7 +8,7 @@ import random
 import numpy as np
 import ctypes as C
 import sys
-import ibeis.detecttools.ctypes_interface as ctypes_interface
+import wbia.detecttools.ctypes_interface as ctypes_interface
 import utool as ut
 
 ut.noinject(__name__, '[pyrf_helpers]')


### PR DESCRIPTION
We are in the middle of renaming our repos from ibeis to wbia.

```
git grep -l ibeis pyrf _test _graveyard | xargs sed -i \
    -e 's/\(from\|import\) ibeis\(\.\| \|$\)/\1 wbia\2/g' \
    -e 's/ibeisdata/wbiadata/g'
```