### PR TITLE
Add and run pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+
+  - repo: local
+    hooks:
+      - id: brunette
+        name: brunette
+        description: Run Brunette on Python code (fork of Black).
+        entry: brunette --config=setup.cfg
+        language: system
+        types: [python]
   - repo: https://github.com/psf/black
     rev: stable
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,15 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 
+  - repo: https://github.com/iconmaster5326/cmake-format-pre-commit-hook
+    rev: master
+    hooks:
+      - id: cmake-format
+        exclude: >
+          (?x)^(
+              .*.cmake.in
+          )$
+
   - repo: local
     hooks:
       - id: brunette

--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(PKG_DESC "Random Forest / Hough Voting Detection Algorithm")
 set(pkg_conf_file ${CMAKE_CURRENT_BINARY_DIR}/pyrf.pc)
 configure_file(pyrf.pc.in ${pkg_conf_file} @ONLY)
-install(FILES ${pkg_conf_file}
-    DESTINATION ${PYRF_LIB_INSTALL_DIR}/pkgconfig/ COMPONENT pkgconfig)
+install(
+  FILES ${pkg_conf_file}
+  DESTINATION ${PYRF_LIB_INSTALL_DIR}/pkgconfig/
+  COMPONENT pkgconfig)

--- a/CMake/FindPyRF.cmake
+++ b/CMake/FindPyRF.cmake
@@ -1,27 +1,25 @@
-###############################################################################
+# ##############################################################################
 # Find PyRF
 #
-# This sets the following variables:
-# PYRF_FOUND - True if pyrf was found.
+# This sets the following variables: PYRF_FOUND - True if pyrf was found.
 # PYRF_INCLUDE_DIRS - Directories containing the pyrf include files.
-# PYRF_LIBRARIES - Libraries needed to use pyrf.
-# PYRF_DEFINITIONS - Compiler flags for pyrf.
+# PYRF_LIBRARIES - Libraries needed to use pyrf. PYRF_DEFINITIONS - Compiler
+# flags for pyrf.
 
 find_package(PkgConfig)
 pkg_check_modules(PC_PYRF pyrf)
 set(PYRF_DEFINITIONS ${PC_PYRF_CFLAGS_OTHER})
 
-find_path(PYRF_INCLUDE_DIR pyrf/pyrf.hpp
-    HINTS ${PC_PYRF_INCLUDEDIR} ${PC_PYRF_INCLUDE_DIRS})
+find_path(PYRF_INCLUDE_DIR pyrf/pyrf.hpp HINTS ${PC_PYRF_INCLUDEDIR}
+                                               ${PC_PYRF_INCLUDE_DIRS})
 
-find_library(PYRF_LIBRARY pyrf
-    HINTS ${PC_PYRF_LIBDIR} ${PC_PYRF_LIBRARY_DIRS})
+find_library(PYRF_LIBRARY pyrf HINTS ${PC_PYRF_LIBDIR} ${PC_PYRF_LIBRARY_DIRS})
 
 set(PYRF_INCLUDE_DIRS ${PYRF_INCLUDE_DIR})
 set(PYRF_LIBRARIES ${PYRF_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PyRF DEFAULT_MSG
-    PYRF_LIBRARY PYRF_INCLUDE_DIR)
+find_package_handle_standard_args(PyRF DEFAULT_MSG PYRF_LIBRARY
+                                  PYRF_INCLUDE_DIR)
 
 mark_as_advanced(PYRF_LIBRARY PYRF_INCLUDE_DIR)

--- a/CMake/pyrf_utils.cmake
+++ b/CMake/pyrf_utils.cmake
@@ -1,45 +1,45 @@
 macro(GET_OS_INFO)
-    string(REGEX MATCH "Linux" OS_IS_LINUX ${CMAKE_SYSTEM_NAME})
-    string(REGEX MATCH "Darwin" OS_IS_MACOS ${CMAKE_SYSTEM_NAME})
-    set(PYRF_LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
-    set(PYRF_INCLUDE_INSTALL_DIR
-        "include/${PROJECT_NAME_LOWER}-${PYRF_VERSION_MAJOR}.${PYRF_VERSION_MINOR}")
+  string(REGEX MATCH "Linux" OS_IS_LINUX ${CMAKE_SYSTEM_NAME})
+  string(REGEX MATCH "Darwin" OS_IS_MACOS ${CMAKE_SYSTEM_NAME})
+  set(PYRF_LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
+  set(PYRF_INCLUDE_INSTALL_DIR
+      "include/${PROJECT_NAME_LOWER}-${PYRF_VERSION_MAJOR}.${PYRF_VERSION_MINOR}"
+  )
 endmacro(GET_OS_INFO)
 
-
 macro(DISSECT_VERSION)
-    # Find version components
-    message(STATUS "PYRF_VERSION = ${PYRF_VERSION}")
-    string(REGEX REPLACE "^([0-9]+).*" "\\1"
-        PYRF_VERSION_MAJOR "${PYRF_VERSION}")
-    string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
-        PYRF_VERSION_MINOR "${PYRF_VERSION}")
-    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1"
-        PYRF_VERSION_PATCH ${PYRF_VERSION})
-    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+(.*)" "\\1"
-        PYRF_VERSION_CANDIDATE ${PYRF_VERSION})
-    set(PYRF_SOVERSION "${PYRF_VERSION_MAJOR}.${PYRF_VERSION_MINOR}")
-    message(STATUS "PYRF_SOVERSION = ${PYRF_SOVERSION}")
+  # Find version components
+  message(STATUS "PYRF_VERSION = ${PYRF_VERSION}")
+  string(REGEX REPLACE "^([0-9]+).*" "\\1" PYRF_VERSION_MAJOR "${PYRF_VERSION}")
+  string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" PYRF_VERSION_MINOR
+                       "${PYRF_VERSION}")
+  string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" PYRF_VERSION_PATCH
+                       ${PYRF_VERSION})
+  string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+(.*)" "\\1"
+                       PYRF_VERSION_CANDIDATE ${PYRF_VERSION})
+  set(PYRF_SOVERSION "${PYRF_VERSION_MAJOR}.${PYRF_VERSION_MINOR}")
+  message(STATUS "PYRF_SOVERSION = ${PYRF_SOVERSION}")
 endmacro(DISSECT_VERSION)
 
-
 macro(pyrf_add_pyunit file)
-    # find test file
-    set(_file_name _file_name-NOTFOUND)
-    find_file(_file_name ${file} ${CMAKE_CURRENT_SOURCE_DIR})
-    if(NOT _file_name)
-        message(FATAL_ERROR "Can't find pyunit file \"${file}\"")
-    endif(NOT _file_name)
+  # find test file
+  set(_file_name _file_name-NOTFOUND)
+  find_file(_file_name ${file} ${CMAKE_CURRENT_SOURCE_DIR})
+  if(NOT _file_name)
+    message(FATAL_ERROR "Can't find pyunit file \"${file}\"")
+  endif(NOT _file_name)
 
-    # add target for running test
-    string(REPLACE "/" "_" _testname ${file})
-    add_custom_target(pyunit_${_testname}
-                    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bin/run_test.py ${_file_name}
-                    DEPENDS ${_file_name}
-                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
-                    VERBATIM
-                    COMMENT "Running pyunit test(s) ${file}" )
-    # add dependency to 'test' target
-    add_dependencies(pyunit_${_testname} pyrf)
-    add_dependencies(test pyunit_${_testname})
+  # add target for running test
+  string(REPLACE "/" "_" _testname ${file})
+  add_custom_target(
+    pyunit_${_testname}
+    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bin/run_test.py
+            ${_file_name}
+    DEPENDS ${_file_name}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+    VERBATIM
+    COMMENT "Running pyunit test(s) ${file}")
+  # add dependency to 'test' target
+  add_dependencies(pyunit_${_testname} pyrf)
+  add_dependencies(test pyunit_${_testname})
 endmacro(pyrf_add_pyunit)

--- a/CMake/python_utils.cmake
+++ b/CMake/python_utils.cmake
@@ -1,51 +1,42 @@
-###
+#
 # Finds the python binaries, libs, include, and site-packages paths
 #
 # The purpose of this file is to export variables that will be used in
-# kwiver/CMake/utils/kwiver-utils-python.cmake and
-# kwiver/sprokit/conf/sprokit-macro-python.cmake (the latter will eventually be
-# consolidated into the former)
+# kwiver/CMake/utils/kwiver-utils-python.cmake and kwiver/sprokit/conf/sprokit-
+# macro-python.cmake (the latter will eventually be consolidated into the
+# former)
 #
 # User options defined in this file:
 #
-#    MAJOR_PYTHON_VERSION
-#      The major python version to target (either 2 or 3)
-#
+# MAJOR_PYTHON_VERSION The major python version to target (either 2 or 3)
 #
 # Calls find_packages to on python interpreter/libraries which defines:
 #
-#    PYTHON_EXECUTABLE
-#    PYTHON_INCLUDE_DIR
-#    PYTHON_LIBRARY
-#    PYTHON_LIBRARY_DEBUG
+# PYTHON_EXECUTABLE PYTHON_INCLUDE_DIR PYTHON_LIBRARY PYTHON_LIBRARY_DEBUG
 #
 # Exported variables used by python utility functions are:
 #
-#    PYTHON_VERSION
-#      the major/minor python version
+# PYTHON_VERSION the major/minor python version
 #
-#    PYTHON_ABI_FLAGS
-#      Python abstract binary interface flags (used internally for defining
-#      subsequent variables, but settable by the user as an advanced setting)
+# PYTHON_ABI_FLAGS Python abstract binary interface flags (used internally for
+# defining subsequent variables, but settable by the user as an advanced
+# setting)
 #
-#    python_site_packages
-#      Location where python packages are installed relative to your python
-#      install directory. For example:
-#        Windows system install: Lib\site-packages
-#        Debian system install: lib/python2.7/dist-packages
-#        Debian virtualenv install: lib/python3.5/site-packages
+# python_site_packages Location where python packages are installed relative to
+# your python install directory. For example: Windows system install: Lib\site-
+# packages Debian system install: lib/python2.7/dist-packages Debian virtualenv
+# install: lib/python3.5/site-packages
 #
-#    python_sitename
-#      The basename of the python_site_packages directory. This is either
-#      site-packages (in most cases) or dist-packages (if your python was
-#      configured by a debian package manager). If you are using a python
-#      virtualenv (you should be) then this will be site-packages
+# python_sitename The basename of the python_site_packages directory. This is
+# either site-packages (in most cases) or dist-packages (if your python was
+# configured by a debian package manager). If you are using a python virtualenv
+# (you should be) then this will be site-packages
 
-###
+#
 # Private helper function to execute `python -c "<cmd>"`
 #
-# Runs a python command and populates an outvar with the result of stdout.
-# Be careful of indentation if `cmd` is multiline.
+# Runs a python command and populates an outvar with the result of stdout. Be
+# careful of indentation if `cmd` is multiline.
 #
 function(_pycmd outvar cmd)
   execute_process(
@@ -60,38 +51,40 @@ ${cmd}\"\"\"")
   endif()
   # Remove supurflous newlines (artifacts of print)
   string(STRIP "${_output}" _output)
-  set(${outvar} "${_output}" PARENT_SCOPE)
+  set(${outvar}
+      "${_output}"
+      PARENT_SCOPE)
 endfunction()
 
-
-###
+#
 # Python major version user option
 #
 
 # Respect the PYTHON_VERSION_MAJOR version if it is set
-if (PYTHON_VERSION_MAJOR)
+if(PYTHON_VERSION_MAJOR)
   set(DEFAULT_PYTHON_MAJOR ${PYTHON_VERSION_MAJOR})
 else()
   set(DEFAULT_PYTHON_MAJOR "3")
 endif()
 
-
-set(MAJOR_PYTHON_VERSION "${DEFAULT_PYTHON_MAJOR}" CACHE STRING "Python version to use: 3 or 2")
+set(MAJOR_PYTHON_VERSION
+    "${DEFAULT_PYTHON_MAJOR}"
+    CACHE STRING "Python version to use: 3 or 2")
 set_property(CACHE MAJOR_PYTHON_VERSION PROPERTY STRINGS "3" "2")
 
-
-###
+#
 # Detect major version change (part1)
 #
-# Clear cached variables when the user changes major python versions.
-# When this happens, we need to re-find the bin, include, and libs
+# Clear cached variables when the user changes major python versions. When this
+# happens, we need to re-find the bin, include, and libs
 #
-if (NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
+if(NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
   # but dont clobber initial settings in the instance they are specified via
   # commandline (e.g  cmake -DPYTHON_EXECUTABLE=/my/special/python)
-  if (__prev_kwiver_pyversion)
+  if(__prev_kwiver_pyversion)
     message(STATUS "The Python version changed; refinding the interpreter")
-    message(STATUS "The previous Python version was: \"${__prev_kwiver_pyversion}\"")
+    message(
+      STATUS "The previous Python version was: \"${__prev_kwiver_pyversion}\"")
     unset(__prev_kwiver_pyversion CACHE)
     unset(PYTHON_EXECUTABLE CACHE)
     unset(PYTHON_INCLUDE_DIR CACHE)
@@ -101,18 +94,17 @@ if (NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
   endif()
 endif()
 
-
-###
 #
 # Mark the previous version so we can determine when python versions change
 #
-set(__prev_kwiver_pyversion "${MAJOR_PYTHON_VERSION}" CACHE INTERNAL
-  "allows us to determine if the user changes python version")
+set(__prev_kwiver_pyversion
+    "${MAJOR_PYTHON_VERSION}"
+    CACHE INTERNAL "allows us to determine if the user changes python version")
 
-###
+#
 # Python interpreter and libraries
 #
-if (MAJOR_PYTHON_VERSION STREQUAL "3")
+if(MAJOR_PYTHON_VERSION STREQUAL "3")
   # note, 3.4 is a minimum version
   find_package(PythonInterp 3.4 REQUIRED)
   find_package(PythonLibs 3.4 REQUIRED)
@@ -122,58 +114,64 @@ else()
 endif()
 include_directories(SYSTEM ${PYTHON_INCLUDE_DIR})
 
-
-###
+#
 # Python site-packages
 #
 # Get canonical directory for python site packages (relative to install
 # location).  It varys from system to system.
 #
-_pycmd(python_site_packages "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
+_pycmd(
+  python_site_packages
+  "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
 message(STATUS "python_site_packages = ${python_site_packages}")
-# Current usage determines most of the path in alternate ways.
-# All we need to supply is the '*-packages' directory name.
-# Customers could be converted to accept a larger part of the path from this function.
+# Current usage determines most of the path in alternate ways. All we need to
+# supply is the '*-packages' directory name. Customers could be converted to
+# accept a larger part of the path from this function.
 get_filename_component(python_sitename ${python_site_packages} NAME)
 
-
-###
+#
 # Python major/minor version
 #
-# Use the executable to find the major/minor version.
-# If you want to change this, then change the executable.
+# Use the executable to find the major/minor version. If you want to change
+# this, then change the executable.
 #
 _pycmd(PYTHON_VERSION "import sys; print(sys.version[0:3])")
 # assert that the right python version was found
 if(NOT PYTHON_VERSION MATCHES "^${MAJOR_PYTHON_VERSION}.*")
   message(STATUS "MAJOR_PYTHON_VERSION = ${MAJOR_PYTHON_VERSION}")
   message(STATUS "PYTHON_VERSION = ${PYTHON_VERSION}")
-  message(FATAL_ERROR "Requested python \"${MAJOR_PYTHON_VERSION}\" but got \"${PYTHON_VERSION}\"")
+  message(
+    FATAL_ERROR
+      "Requested python \"${MAJOR_PYTHON_VERSION}\" but got \"${PYTHON_VERSION}\""
+  )
 endif()
 
-
-###
+#
 # Python ABI Flags
 #
 # See PEP 3149 - ABI (application binary interface) version tagged .so files
 # https://www.python.org/dev/peps/pep-3149/
 #
-if (MAJOR_PYTHON_VERSION STREQUAL "3")
+if(MAJOR_PYTHON_VERSION STREQUAL "3")
   # In python 3, we can determine what the ABI flags are
-  _pycmd(_python_abi_flags "from distutils import sysconfig; print(sysconfig.get_config_var('ABIFLAGS'))")
+  _pycmd(
+    _python_abi_flags
+    "from distutils import sysconfig; print(sysconfig.get_config_var('ABIFLAGS'))"
+  )
 else()
   # Not sure if ABI flags are easilly found (or are even used in python2)
   set(_python_abi_flags, "")
 endif()
-set(PYTHON_ABIFLAGS "${_python_abi_flags}"
-  CACHE STRING "The ABI flags for the version of Python being used")
+set(PYTHON_ABIFLAGS
+    "${_python_abi_flags}"
+    CACHE STRING "The ABI flags for the version of Python being used")
 mark_as_advanced(PYTHON_ABIFLAGS)
 
-
-###
+#
 # Status string for debugging
 #
-set(PYTHON_CONFIG_STATUS "
+set(PYTHON_CONFIG_STATUS
+    "
 PYTHON_CONFIG_STATUS
   * PYTHON_EXECUTABLE = \"${PYTHON_EXECUTABLE}\"
   * PYTHON_INCLUDE_DIR = \"${PYTHON_INCLUDE_DIR}\"

--- a/CMake/python_utils.cmake
+++ b/CMake/python_utils.cmake
@@ -52,7 +52,7 @@ function(_pycmd outvar cmd)
     COMMAND "${PYTHON_EXECUTABLE}" -c "${cmd}"
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _output
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(NOT ${_exitcode} EQUAL 0)
     message(ERROR "Failed when running python code: \"\"\"
 ${cmd}\"\"\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.13.0)
 
-set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
 if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0003 NEW)
-    cmake_policy(SET CMP0042 NEW)
+  cmake_policy(SET CMP0003 NEW)
+  cmake_policy(SET CMP0042 NEW)
 endif(COMMAND cmake_policy)
 
 project(pyrf LANGUAGES C CXX)
@@ -17,8 +17,7 @@ function(_pycmd outvar cmd)
     COMMAND python -c "${cmd}"
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _output
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(NOT ${_exitcode} EQUAL 0)
     message(ERROR "Failed when running python code: \"\"\"
 ${cmd}\"\"\"")
@@ -26,70 +25,72 @@ ${cmd}\"\"\"")
   endif()
   # Remove supurflous newlines (artifacts of print)
   string(STRIP "${_output}" _output)
-  set(${outvar} "${_output}" PARENT_SCOPE)
+  set(${outvar}
+      "${_output}"
+      PARENT_SCOPE)
 endfunction()
 _pycmd(PYRF_VERSION "import setup; print(setup.version)")
 
 message(STATUS "PYRF_VERSION = ${PYRF_VERSION}")
 
-DISSECT_VERSION()
-GET_OS_INFO()
+dissect_version()
+get_os_info()
 
-if (OS_IS_MACOS)
-    message(STATUS "INCLUDING MACPORTS")
+if(OS_IS_MACOS)
+  message(STATUS "INCLUDING MACPORTS")
 
-    find_package(Eigen3 3 REQUIRED NO_MODULE)
+  find_package(Eigen3 3 REQUIRED NO_MODULE)
 
-    include_directories(/opt/local/include)
-    link_directories(/opt/local/lib)
+  include_directories(/opt/local/include)
+  link_directories(/opt/local/lib)
 
-    set(CMAKE_INSTALL_RPATH "/opt/local/lib")
+  set(CMAKE_INSTALL_RPATH "/opt/local/lib")
 
-    # Add flags to support clang2
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")
+  # Add flags to support clang2
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")
 endif()
 
-# Setup basic python stuff and ensure we have skbuild
-#list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/CMake")
-#include( skbuild-helpers )
+# Setup basic python stuff and ensure we have skbuild list(INSERT
+# CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/CMake") include( skbuild-helpers )
 
-#######################################
+# ##############################################################################
 
 # detect if using the Clang compiler
 if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
-endif ()
+endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANGXX 1)
-endif ()
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # Add an "uninstall" target
-CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/uninstall_target.cmake.in"
-    "${PROJECT_BINARY_DIR}/uninstall_target.cmake" IMMEDIATE @ONLY)
-ADD_CUSTOM_TARGET (uninstall "${CMAKE_COMMAND}" -P
-    "${PROJECT_BINARY_DIR}/uninstall_target.cmake")
+configure_file("${PROJECT_SOURCE_DIR}/cmake/uninstall_target.cmake.in"
+               "${PROJECT_BINARY_DIR}/uninstall_target.cmake" IMMEDIATE @ONLY)
+add_custom_target(uninstall "${CMAKE_COMMAND}" -P
+                            "${PROJECT_BINARY_DIR}/uninstall_target.cmake")
 
-# Set the build type.  Options are:
-#  Debug          : w/ debug symbols, w/o optimization
-#  Release        : w/o debug symbols, w/ optimization
-#  RelWithDebInfo : w/ debug symbols, w/ optimization
-#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+# Set the build type.  Options are: Debug          : w/ debug symbols, w/o
+# optimization Release        : w/o debug symbols, w/ optimization
+# RelWithDebInfo : w/ debug symbols, w/ optimization MinSizeRel     : w/o debug
+# symbols, w/ optimization, stripped binaries
 
-if (NOT CMAKE_BUILD_TYPE)
-    #set(CMAKE_BUILD_TYPE Release)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
-    #set(CMAKE_BUILD_TYPE Debug)
+if(NOT CMAKE_BUILD_TYPE)
+  # set(CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE
+      RelWithDebInfo
+      CACHE STRING "Build type" FORCE)
+  # set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-#set the default path for built executables to the "bin" directory
+# set the default path for built executables to the "bin" directory
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-#set the default path for built libraries to the "lib" directory
+# set the default path for built libraries to the "lib" directory
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 # set output path for tests
 set(TEST_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/test)
@@ -98,30 +99,31 @@ option(BUILD_TESTS "Build tests" ON)
 option(BUILD_DOC "Build documentation" ON)
 option(USE_OPENMP "Use OpenMP multi-threading" ON)
 
-find_package( OpenCV REQUIRED )
-IF(OpenCV_FOUND)
+find_package(OpenCV REQUIRED)
+if(OpenCV_FOUND)
   include_directories(${OpenCV_INCLUDE_DIR})
-ELSE()
+else()
   message(FATAL_ERROR "OpenCV NOT found")
-ENDIF()
+endif()
 
-if (USE_OPENMP)
-    find_package(OpenMP)
-    if(OPENMP_FOUND)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-    else()
-        message(WARNING "OpenMP NOT found")
-    endif()
+if(USE_OPENMP)
+  find_package(OpenMP)
+  if(OPENMP_FOUND)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS
+        "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  else()
+    message(WARNING "OpenMP NOT found")
+  endif()
 endif()
 
 find_package(PkgConfig REQUIRED)
 
-#set the C/C++ include path to the "include" directory
+# set the C/C++ include path to the "include" directory
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src/cpp)
 
-add_definitions("-Wall -Wno-unknown-pragmas -Wno-unused-function" )
+add_definitions("-Wall -Wno-unknown-pragmas -Wno-unused-function")
 
 # install and export variables
 set(config_install_dir "lib/cmake/${PROJECT_NAME}")
@@ -131,59 +133,46 @@ set(project_config "${generated_dir}/pyrf-config.cmake")
 set(targets_export_name "pyrf-targets")
 set(namespace "pyrf::")
 
-if (SKBUILD)
+if(SKBUILD)
   # Override output paths when using scikit-build
   set(PYRF_LIB_INSTALL_DIR "pyrf/lib")
   set(PYRF_INCLUDE_INSTALL_DIR "pyrf/include")
 endif()
 
-if (NOT SKBUILD)
-  add_subdirectory( CMake )
+if(NOT SKBUILD)
+  add_subdirectory(CMake)
 endif()
-add_subdirectory( src/cpp )
-if (BUILD_TESTS)
-  add_subdirectory( test )
-endif (BUILD_TESTS)
+add_subdirectory(src/cpp)
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif(BUILD_TESTS)
 
-# CMake configuration file creation
-# Include module with fuction 'write_basic_package_version_file'
+# CMake configuration file creation Include module with fuction
+# 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
 
-# Configure 'pyrf-config-version.cmake'
-# Note: PYRF_VERSION is used as a VERSION
+# Configure 'pyrf-config-version.cmake' Note: PYRF_VERSION is used as a VERSION
 write_basic_package_version_file(
-    "${version_config}"
-    VERSION ${PYRF_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+  "${version_config}"
+  VERSION ${PYRF_VERSION}
+  COMPATIBILITY SameMajorVersion)
 
-# Configure 'pyrf-config.cmake'
-# Use variables:
-#   * targets_export_name
-#   * PROJECT_NAME
-configure_package_config_file(
-  "cmake/Config.cmake.in"
-    "${project_config}"
-    INSTALL_DESTINATION "${config_install_dir}"
-)
+# Configure 'pyrf-config.cmake' Use variables: * targets_export_name *
+# PROJECT_NAME
+configure_package_config_file("cmake/Config.cmake.in" "${project_config}"
+                              INSTALL_DESTINATION "${config_install_dir}")
 
-if (NOT SKBUILD)
-  # Config
-  #   * <prefix>/lib/cmake/pyrf/pyrf-config.cmake
-  #   * <prefix>/lib/cmake/pyrf/pyrf-config-version.cmake
+if(NOT SKBUILD)
+  # Config * <prefix>/lib/cmake/pyrf/pyrf-config.cmake *
+  # <prefix>/lib/cmake/pyrf/pyrf-config-version.cmake
+  install(FILES "${project_config}" "${version_config}"
+          DESTINATION "${config_install_dir}")
+  # Config * <prefix>/lib/cmake/pyrf/pyrf-targets.cmake
   install(
-      FILES "${project_config}" "${version_config}"
-      DESTINATION "${config_install_dir}"
-  )
-  # Config
-  #   * <prefix>/lib/cmake/pyrf/pyrf-targets.cmake
-  install(
-      EXPORT "${targets_export_name}"
-      NAMESPACE "${namespace}"
-      DESTINATION "${config_install_dir}"
-  )
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}")
 endif()
-
 
 # CPACK options
 
@@ -204,7 +193,7 @@ if(EXISTS ${NSIS_PROGRAM})
 endif(EXISTS ${NSIS_PROGRAM})
 # dpkg
 find_program(PACKAGE_MAKER_PROGRAM PackageMaker
-	    HINTS /Developer/Applications/Utilities)
+             HINTS /Developer/Applications/Utilities)
 if(EXISTS ${PACKAGE_MAKER_PROGRAM})
   list(APPEND CPACK_GENERATOR "PackageMaker")
 endif(EXISTS ${PACKAGE_MAKER_PROGRAM})
@@ -215,12 +204,11 @@ set(CPACK_SET_DESTDIR ON)
 include(InstallRequiredSystemLibraries)
 set(CPACK_PACKAGE_CONTACT "Marius Muja")
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-SET(CPACK_PACKAGE_VERSION ${PYRF_VERSION})
-SET(CPACK_PACKAGE_VERSION_MAJOR ${PYRF_VERSION_MAJOR})
-SET(CPACK_PACKAGE_VERSION_MINOR ${PYRF_VERSION_MINOR})
-SET(CPACK_PACKAGE_VERSION_PATCH ${PYRF_VERSION_PATCH})
+set(CPACK_PACKAGE_VERSION ${PYRF_VERSION})
+set(CPACK_PACKAGE_VERSION_MAJOR ${PYRF_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PYRF_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PYRF_VERSION_PATCH})
 include(CPack)
-
 
 message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,9 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 
 # Exclude the git directory and virtualenv directory (as `.env`)
 exclude = .git,.env
+
+[tool:brunette]
+line-length = 90
+verbose = false
+# skip-string-normalization = true
+single-quotes = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # This section configures `flake8`, the python linting utility.
 # See also https://flake8.pycqa.org/en/latest/user/configuration.html
-ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806,W503
+ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E231,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806,W503
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
 # D102 - Missing docstring in public method
@@ -22,6 +22,7 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 # E203 - whitespace before ‘:’
 # E221 - multiple spaces before operator
 # E222 - multiple spaces after operator
+# E231 - missing whitespace after ','
 # E241 - multiple spaces after ‘,’
 # E265 - block comment should start with ‘# ‘
 # E271 - multiple spaces after keyword
@@ -37,6 +38,31 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 # N806 - variable in function should be lowercase
 # N* codes come from pep8-naming, which integrates with flake8
 # See also https://github.com/PyCQA/pep8-naming#error-codes
+
+# W503 - line break before binary operator
+#
+# The reason for adding W503 to the ignored list is because W503 (Line break
+# occurred before a binary operator) and W504 (Line break occurred after a binary
+# operator) are both enabled in flake8 by default for some reason.  But they are
+# mutually exclusive so one has to be disabled / ignored.
+#
+# According to pep8 at the time of the commit
+# https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
+#
+# ```
+# income = (gross_wages +
+#           taxable_interest +
+#           (dividends - qualified_dividends) -
+#           ira_deduction -
+#           student_loan_interest)
+# income = (gross_wages
+#           + taxable_interest
+#           + (dividends - qualified_dividends)
+#           - ira_deduction
+#           - student_loan_interest)
+# ```
+#
+# W504 (Line break occurred after a binary operator) is the correct behavior.
 
 # Exclude the git directory and virtualenv directory (as `.env`)
 exclude = .git,.env

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,1 @@
-
-add_subdirectory( cpp )
+add_subdirectory(cpp)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-#include_directories(${CMAKE_SOURCE_DIR}/include algorithms ext util nn .)
+# include_directories(${CMAKE_SOURCE_DIR}/include algorithms ext util nn .)
 
 message(STATUS "PYRF_VERSION = ${PYRF_VERSION}")
 set(PYRF_VERSION ${PYRF_VERSION})
@@ -10,7 +10,8 @@ add_definitions(-D_PYRF_VERSION=${PYRF_VERSION})
 add_definitions(-DPYRF_VERSION_=${PYRF_VERSION})
 add_definitions(-DPYRF_VERSION=${PYRF_VERSION})
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyrf/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/pyrf/config.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyrf/config.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/pyrf/config.h)
 
 set(CPP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/pyrf/CRForestDetector.cpp
@@ -23,54 +24,52 @@ add_library(pyrf_s STATIC ${CPP_SOURCES})
 target_link_libraries(pyrf_s ${OpenCV_LIBS})
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-    set_target_properties(pyrf_s PROPERTIES COMPILE_FLAGS -fPIC)
+  set_target_properties(pyrf_s PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
 
 set_property(TARGET pyrf_s PROPERTY COMPILE_DEFINITIONS PYRF_STATIC)
 
 add_library(pyrf SHARED "${CMAKE_CURRENT_SOURCE_DIR}/pyrf/pyrf.h")
 
-if (OS_IS_LINUX)
-    set_target_properties(pyrf PROPERTIES LINKER_LANGUAGE CXX)
-    set(LINK_FLAG_PREFIX "-Wl,--whole-archive")
-    set(LINK_FLAG_POSTFIX "-Wl,--no-whole-archive")
-elseif (OS_IS_MACOS)
-    set(LINK_FLAG_PREFIX "-Wl,-all_load")
-else ()
-    set_target_properties(pyrf PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
-    set(LINK_FLAG_PREFIX "/WHOLEARCHIVE")
-endif ()
+if(OS_IS_LINUX)
+  set_target_properties(pyrf PROPERTIES LINKER_LANGUAGE CXX)
+  set(LINK_FLAG_PREFIX "-Wl,--whole-archive")
+  set(LINK_FLAG_POSTFIX "-Wl,--no-whole-archive")
+elseif(OS_IS_MACOS)
+  set(LINK_FLAG_PREFIX "-Wl,-all_load")
+else()
+  set_target_properties(pyrf PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
+  set(LINK_FLAG_PREFIX "/WHOLEARCHIVE")
+endif()
 
 target_link_libraries(pyrf ${LINK_FLAG_PREFIX} pyrf_s ${LINK_FLAG_POSTFIX})
 
-set_target_properties(pyrf PROPERTIES
-    VERSION ${PYRF_VERSION}
-    SOVERSION ${PYRF_SOVERSION}
-    DEFINE_SYMBOL PYRF_EXPORTS
-)
+set_target_properties(
+  pyrf PROPERTIES VERSION ${PYRF_VERSION} SOVERSION ${PYRF_SOVERSION}
+                  DEFINE_SYMBOL PYRF_EXPORTS)
 
 if(NOT SKBUILD)
-    install (
-        TARGETS pyrf pyrf_s
-        EXPORT ${targets_export_name}
-        INCLUDES DESTINATION include
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${PYRF_LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${PYRF_LIB_INSTALL_DIR}
-    )
+  install(
+    TARGETS pyrf pyrf_s
+    EXPORT ${targets_export_name}
+    INCLUDES
+    DESTINATION include
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${PYRF_LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${PYRF_LIB_INSTALL_DIR})
 
-    install (
-        DIRECTORY pyrf
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
-    )
+  install(
+    DIRECTORY pyrf
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 
 else()
-    # Only install the library files when building with skbuild
-    install (
-        TARGETS pyrf pyrf_s
-        EXPORT ${targets_export_name}
-        LIBRARY DESTINATION ${PYRF_LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${PYRF_LIB_INSTALL_DIR}
-    )
+  # Only install the library files when building with skbuild
+  install(
+    TARGETS pyrf pyrf_s
+    EXPORT ${targets_export_name}
+    LIBRARY DESTINATION ${PYRF_LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${PYRF_LIB_INSTALL_DIR})
 endif()


### PR DESCRIPTION
- Add W503 to ignored flake8 warnings in setup.cfg

   The reason for adding W503 to the ignored list is because W503 (Line
  break occurred before a binary operator) and W504 (Line break occurred
  after a binary operator) are both enabled in flake8 by default for some
  reason.  But they are mutually exclusive so one has to be disabled /
  ignored.

- Add brunette pre-commit hook for codestyle correction

   
- Add cmake format pre-commit hook

   
- Run cmake format pre-commit hook
